### PR TITLE
Corrected Issue #34 with back menu entry duplication

### DIFF
--- a/hgl-editor.py
+++ b/hgl-editor.py
@@ -404,6 +404,7 @@ while True:
             print(f"{map_num} - edit {m}")
             game.add_menu_entry('boards_list',str(map_num),f"edit {m}",f"{m}")
             map_num += 1
+        game.add_menu_entry('boards_list','B',"Go Back to main menu")
     else:
         print('No pre-existing map found.')
     print('n - create a new map')
@@ -621,8 +622,6 @@ while True:
             cnt += 1
         print('')
         print(f'Current item: {current_object.model}')
-    if current_menu == 'boards_list':
-        game.add_menu_entry('boards_list','B',"Go Back to main menu")
     if not (current_menu == 'main' and menu_mode == 'hidden'):
         game.display_menu(current_menu,Constants.ORIENTATION_VERTICAL,15)
     for m in dbg_messages:


### PR DESCRIPTION
## Description

Corrected the back menu duplication bug when loading different map files. 

Fixes #34 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
The exact steps for reproduction steps for Issue #34 were in multiple instances of the program. After updating the code the issue no longer exists while other menu functions are unaffected.

![hgl-editor1](https://user-images.githubusercontent.com/24757919/66356165-59912380-e96a-11e9-9a11-a21419e1411d.png)
![hgl-editor2](https://user-images.githubusercontent.com/24757919/66356166-59912380-e96a-11e9-8832-d5cc5d100cbb.png)

**Test Configuration**:
* OS: Linux Mint
* OS version: 19.2 Tina
* Python version: 3.6.8
* Architecture: x64

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [NA] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [NA] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
