### PR TITLE
Add CircleCI for tests and linting 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,14 +23,15 @@ jobs:
             - '/usr/local/bin'
             - '/usr/local/lib/python3.7/site-packages'
       - run:
+          name: Run linting and metrics
+          command: |
+            mkdir reports
+            pipenv run python3 -m flake8 --output-file reports/linter-results
+      - run:
           name: Run unit tests under tests folder
           command: |
             pipenv run python3 -m unittest discover -s tests
           when: always
-      - run:
-          name: Run linting and metrics
-          command: |
-            pipenv run python3 -m flake8 --output-file reports/linter-results
           when: always
       - store_test_results:
           path: reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,16 +22,31 @@ jobs:
             - '.venv'
             - '/usr/local/bin'
             - '/usr/local/lib/python3.7/site-packages'
+
+  test:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
       - run:
-          name: run unit tests under tests folder
+          name: Run unit tests under tests folder
           command: |
             pipenv run python3 -m unittest discover -s tests
+          when: always
       - run:
-          name: run linting and metrics
+          name: Run linting and metrics
           command: |
-            pipenv run python3 -m flake8 --output-file test-results
+            pipenv run python3 -m flake8 --output-file reports/linter-results
+          when: always
       - store_test_results:
-          path: test-results
+          path: reports
       - store_artifacts:
-          path: test-results
+          path: reports
           destination: tr1
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/hac-game-lib
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          PIPENV_VENV_IN_PROJECT: true
+    steps:
+      - checkout
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
+      - restore_cache:
+          key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+      - run:
+          command: |
+            sudo pip3 install pipenv
+            pipenv install
+      - save_cache:
+          key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - '.venv'
+            - '/usr/local/bin'
+            - '/usr/local/lib/python3.7/site-packages'
+      - run:
+        name: run unit tests under tests folder
+          command: |
+            pipenv run python3 -m unittest discover -s tests
+      - run:
+          name: run linting and metrics
+          command: |
+            pipenv run python3 -m flake8 --output-file test-results
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: test-results
+          destination: tr1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run:
           command: |
             sudo pip3 install pipenv
-            pipenv install
+            pipenv install --dev
       - save_cache:
           key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,6 @@ jobs:
             - '.venv'
             - '/usr/local/bin'
             - '/usr/local/lib/python3.7/site-packages'
-
-  test:
-    docker:
-      - image: circleci/python:3.7
-    steps:
-      - checkout
       - run:
           name: Run unit tests under tests folder
           command: |
@@ -42,11 +36,3 @@ jobs:
           path: reports
       - store_artifacts:
           path: reports
-          destination: tr1
-
-workflows:
-  version: 2
-  build_and_test:
-    jobs:
-      - build
-      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             - '/usr/local/bin'
             - '/usr/local/lib/python3.7/site-packages'
       - run:
-        name: run unit tests under tests folder
+          name: run unit tests under tests folder
           command: |
             pipenv run python3 -m unittest discover -s tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,11 @@ jobs:
           command: |
             mkdir reports
             pipenv run python3 -m flake8 --output-file reports/linter-results
+          when: always
       - run:
           name: Run unit tests under tests folder
           command: |
             pipenv run python3 -m unittest discover -s tests
-          when: always
           when: always
       - store_test_results:
           path: reports


### PR DESCRIPTION
# Add CircleCI for tests and linting 

## Description

Includes the `config.yml` file that builds the environment, runs linting rules with flake8 to an output file and finally runs the tests. One tests is currently failing and there are lots of code violations detected by flake8 default rules. 

Fixes #45