### PR TITLE
Add character mapping for arrow buttons

### DIFF
--- a/gamelib/Utils.py
+++ b/gamelib/Utils.py
@@ -82,8 +82,17 @@ def get_key():
     remember_attributes=termios.tcgetattr(fd)
     tty.setraw(sys.stdin.fileno())
     character=sys.stdin.read(1)
-    termios.tcsetattr(fd, termios.TCSADRAIN, remember_attributes)
-    return character
+    try:
+        # Captures the special character preceding an arrow key
+        if character == '\x1b':
+            character = sys.stdin.read(2)
+            # Maps the arrow keys to predefined wasd layout
+            character_map = {'[A':'w', '[B':'s','[D':'a','[C':'d'}
+
+            return character_map[character]
+        return character
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, remember_attributes)
 
 ## the warn() function print a message prefixed by a yellow WARNING.
 def warn(message):


### PR DESCRIPTION
# Pull Request Template

## Description

This implementation does not use external packages.
This allows multi character inputs such as the arrow keys to be used.
However, currently only arrow keys have been mapped to the wasd layout.

The only limitation is reading specific keys such as Ctrl, Alt, etc.

Fixes #27 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran using the arrow keys on hgl-base_game.py

**Test Configuration**:
* OS: MacOS
* OS version: MacOS Mojave
* Python version: 3.7.0
* Architecture: 64-bit

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
