### PR TITLE
:wrench: add a legacy requirements.txt

### DIFF
--- a/.legacy/requirements.txt
+++ b/.legacy/requirements.txt
@@ -1,0 +1,3 @@
+colorama>=0.4.1
+configparser>=3.7.3
+readchar>=2.0.1

--- a/.legacy/requirements.txt
+++ b/.legacy/requirements.txt
@@ -1,3 +1,4 @@
+# This file needs to be updated everytime the Pipenv files are.
 colorama>=0.4.1
 configparser>=3.7.3
 readchar>=2.0.1

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,9 @@ ipython = "*"
 [packages]
 colorama = ">=0.3.8"
 readchar = ">=2.0.0"
+configparser = ">=3.7.3"
 
 [requires]
 python_version = "3.7"
+
+# Please update the .legacy/requirements.txt with new dependencies added here.


### PR DESCRIPTION
# Pull Request Template

## Description

Lots of automated tools are still using requirements.txt and are unable to use Pipfile. To benefitfrom these tools (readthedocs.io for example) we need to re-introduce a requirements.txt.

Fixes #78 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
