### PR TITLE
Ignore top import lint error in examples

### DIFF
--- a/examples/tutorials/03-game-design/01-board-loading-and-level-fixing.py
+++ b/examples/tutorials/03-game-design/01-board-loading-and-level-fixing.py
@@ -5,14 +5,12 @@ import os
 
 sys.path.append(os.path.abspath(os.path.join("..", "..", "..")))
 
-# fmt: off
-from gamelib.Game import Game
-from gamelib.Characters import Player
-from gamelib.Structures import Door
-import gamelib.Sprites as Sprites
-import gamelib.Constants as Constants
-import gamelib.Utils as Utils
-# fmt: on
+from gamelib.Game import Game  # noqa: E402
+from gamelib.Characters import Player  # noqa: E402
+from gamelib.Structures import Door  # noqa: E402
+import gamelib.Sprites as Sprites  # noqa: E402
+import gamelib.Constants as Constants  # noqa: E402
+import gamelib.Utils as Utils  # noqa: E402
 
 # Here are our global variables (it is usually a bad idea to use global variables but
 # it will simplify that tutorial, keep in mind that we don't usually rely on global

--- a/examples/tutorials/03-game-design/03-whale-logic.py
+++ b/examples/tutorials/03-game-design/03-whale-logic.py
@@ -6,15 +6,14 @@ import time
 
 sys.path.append(os.path.abspath(os.path.join("..", "..", "..")))
 
-# fmt: off
-from gamelib.Game import Game
-from gamelib.Characters import Player
-from gamelib.Characters import NPC
-import gamelib.Sprites as Sprites
-import gamelib.Constants as Constants
-import gamelib.Utils as Utils
-from gamelib.Structures import Door
-# fmt: on
+from gamelib.Game import Game  # noqa: E402
+from gamelib.Characters import Player  # noqa: E402
+from gamelib.Characters import NPC  # noqa: E402
+import gamelib.Sprites as Sprites  # noqa: E402
+import gamelib.Constants as Constants  # noqa: E402
+import gamelib.Utils as Utils  # noqa: E402
+from gamelib.Structures import Door  # noqa: E402
+
 
 def refresh_screen():
     global g

--- a/examples/tutorials/03-game-design/99-final-game.py
+++ b/examples/tutorials/03-game-design/99-final-game.py
@@ -7,18 +7,16 @@ import random
 
 sys.path.append(os.path.abspath(os.path.join("..", "..", "..")))
 
-# fmt: off
-from gamelib.Game import Game
-from gamelib.Board import Board
-from gamelib.Characters import Player
-from gamelib.Characters import NPC
-import gamelib.Sprites as Sprites
-import gamelib.Constants as Constants
-import gamelib.Utils as Utils
-from gamelib.Structures import Door
-from gamelib.Structures import Treasure
-from gamelib.BoardItem import BoardItemVoid
-# fmt: on
+from gamelib.Game import Game  # noqa: E402
+from gamelib.Board import Board  # noqa: E402
+from gamelib.Characters import Player  # noqa: E402
+from gamelib.Characters import NPC  # noqa: E402
+import gamelib.Sprites as Sprites  # noqa: E402
+import gamelib.Constants as Constants  # noqa: E402
+import gamelib.Utils as Utils  # noqa: E402
+from gamelib.Structures import Door  # noqa: E402
+from gamelib.Structures import Treasure  # noqa: E402
+from gamelib.BoardItem import BoardItemVoid  # noqa: E402
 
 # Here are our global variables (it is usually a bad idea to use global variables but
 # it will simplify that tutorial, keep in mind that we don't usually rely on global


### PR DESCRIPTION
## Description

Ignore top import lint error in examples to finally resolve all `flake8` issues :tada:

Fixes #39 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

**Test Configuration**:
* OS: Archlinux
* OS version: :new: 
* Python version: 3.7.4
* Architecture: x86_64

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
